### PR TITLE
Fix tags with values containing =

### DIFF
--- a/event.go
+++ b/event.go
@@ -153,12 +153,12 @@ example:
 			tags := make(nostr.Tags, 0, 5)
 			for _, tagFlag := range c.StringSlice("tag") {
 				// tags are in the format key=value
-				spl := strings.Split(tagFlag, "=")
-				if len(spl) == 2 && len(spl[0]) > 0 {
-					tag := nostr.Tag{spl[0]}
+				tagName, tagValue, found := strings.Cut(tagFlag, "=")
+				tag := []string{tagName}
+				if found {
 					// tags may also contain extra elements separated with a ";"
-					spl2 := strings.Split(spl[1], ";")
-					tag = append(tag, spl2...)
+					tagValues := strings.Split(tagValue, ";")
+					tag = append(tag, tagValues...)
 					// ~
 					tags = append(tags, tag)
 				}

--- a/example_test.go
+++ b/example_test.go
@@ -7,9 +7,9 @@ func ExampleEventBasic() {
 }
 
 func ExampleEventComplex() {
-	app.Run([]string{"nak", "event", "--ts", "1699485669", "-k", "11", "-c", "skjdbaskd", "--sec", "17", "-t", "t=spam", "-e", "36d88cf5fcc449f2390a424907023eda7a74278120eebab8d02797cd92e7e29c", "-t", "r=https://abc.def;nothing"})
+	app.Run([]string{"nak", "event", "--ts", "1699485669", "-k", "11", "-c", "skjdbaskd", "--sec", "17", "-t", "t=spam", "-e", "36d88cf5fcc449f2390a424907023eda7a74278120eebab8d02797cd92e7e29c", "-t", "r=https://abc.def?name=foobar;nothing"})
 	// Output:
-	// {"id":"aec4de6d051a7c2b6ca2d087903d42051a31e07fb742f1240970084822de10a6","pubkey":"2fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f","created_at":1699485669,"kind":11,"tags":[["t","spam"],["r","https://abc.def","nothing"],["e","36d88cf5fcc449f2390a424907023eda7a74278120eebab8d02797cd92e7e29c"]],"content":"skjdbaskd","sig":"1165ac7a27d774d351ef19c8e918fb22f4005fcba193976c3d7edba6ef87ead7f14467f376a9e199f8371835368d86a8506f591e382528d00287fb168a7b8f38"}
+	// {"id":"19aba166dcf354bf5ef64f4afe69ada1eb851495001ee05e07d393ee8c8ea179","pubkey":"2fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f","created_at":1699485669,"kind":11,"tags":[["t","spam"],["r","https://abc.def?name=foobar","nothing"],["e","36d88cf5fcc449f2390a424907023eda7a74278120eebab8d02797cd92e7e29c"]],"content":"skjdbaskd","sig":"cf452def4a68341c897c3fc96fa34dc6895a5b8cc266d4c041bcdf758ec992ec5adb8b0179e98552aaaf9450526a26d7e62e413b15b1c57e0cfc8db6b29215d7"}
 }
 
 func ExampleReq() {


### PR DESCRIPTION
This fixes a bug which would break the generation of tags if they contain a `=` sign.

<details><summary>Before</summary>
<p>

```sh
$ nak event -t u='http://nos.social/.well-known/nostr.json?name=alice'|jq
{
  "id": "6ac3da7d36f171912951b916015af8ab62e7546b9ccb11f1f45fd4d9cd3e5501",
  "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
  "created_at": 1702506899,
  "kind": 1,
  "tags": [],
  "content": "hello from the nostr army knife",
  "sig": "33847bbb1bce221dbcd6be4a50d5e4ad07ec384d8ac6f5e9276d492e568b890b3b90dac271082b7466deff8bd088e0cfff7f632d5043c1e328e26eb01648ee48"
}
```

</p>
</details> 

<details><summary>After</summary>
<p>

```sh
$ nak event -t u='http://nos.social/.well-known/nostr.json?name=alice'|jq
{
  "id": "4895cdf5cbfe2c56fce2795190edb6e8563148c93c5a04d1db4f65173be8c807",
  "pubkey": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
  "created_at": 1702506906,
  "kind": 1,
  "tags": [
    [
      "u",
      "http://nos.social/.well-known/nostr.json?name=alice"
    ]
  ],
  "content": "hello from the nostr army knife",
  "sig": "1a5206b6dee566884d31ee93e832858631b2a9d27d2454ebcfb520e4fc3c4920d74a39f1c291aa80e72074de23ae2186c206e76843696eea745cb00f0f9f401b"
}
```

</p>
</details> 