### PR TITLE
Allow setting private key via ENV variable

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -195,7 +195,13 @@ func gatherSecretKeyOrBunkerFromArguments(ctx context.Context, c *cli.Command) (
 		})
 		return "", bunker, err
 	}
+
+	// Check in the Env for the secret key first
 	sec := c.String("sec")
+	if env, ok := os.LookupEnv("NOSTR_PRIVATE_KEY"); ok {
+		sec = env
+	}
+
 	if c.Bool("prompt-sec") {
 		if isPiped() {
 			return "", nil, fmt.Errorf("can't prompt for a secret key when processing data from a pipe, try again without --prompt-sec")


### PR DESCRIPTION
ENV variables are important for passing in secret keys so that they don't leak into command history and etc.  This simple patch allows you to set NOSTR_PRIVATE_KEY as an environment variable and nak will use this for various actions that require a key if not in bunker mode.