### PR TITLE
feat: use localhost relay without having to type 'ws://'

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -22,7 +22,9 @@ var relay = &cli.Command{
 				return fmt.Errorf("specify the <relay-url>")
 			}
 
-			if !strings.HasPrefix(url, "wss://") && !strings.HasPrefix(url, "ws://") {
+			if strings.HasPrefix(url, "localhost") == true {
+				url = "ws://" + url
+			} else if !strings.HasPrefix(url, "wss://") && !strings.HasPrefix(url, "ws://") {
 				url = "wss://" + url
 			}
 


### PR DESCRIPTION
As someone who has a relay running in localhost, it's pretty annoying to have to type `ws://` every time.