### PR TITLE
fix(decode): handle pubkey flag

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -58,6 +58,10 @@ var decode = &cli.Command{
 				decodeResult = DecodeResult{EventPointer: evp}
 			} else if pp := sdk.InputToProfile(ctx, input); pp != nil {
 				decodeResult = DecodeResult{ProfilePointer: pp}
+				if c.Bool("pubkey") {
+					stdout(pp.PublicKey)
+					return nil
+				}
 			} else if prefix, value, err := nip19.Decode(input); err == nil && prefix == "naddr" {
 				if ep, ok := value.(nostr.EntityPointer); ok {
 					decodeResult = DecodeResult{EntityPointer: &ep}

--- a/example_test.go
+++ b/example_test.go
@@ -67,6 +67,12 @@ func ExampleDecode() {
 	// }
 }
 
+func ExampleDecodePubkey() {
+	app.Run(ctx, []string{"nak", "decode", "-p", "npub10xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqpkge6d"})
+	// Output:
+	// 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+}
+
 func ExampleReq() {
 	app.Run(ctx, []string{"nak", "req", "-k", "1", "-l", "18", "-a", "2fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f", "-e", "aec4de6d051a7c2b6ca2d087903d42051a31e07fb742f1240970084822de10a6"})
 	// Output:


### PR DESCRIPTION
nak decode's subcommand accepts a --pubkey flag to print only the pubkey if applicable instead of JSON, however it wasn't being used.