### PR TITLE
show env var in help, reset terminal mode correctly

### DIFF
--- a/helpers_key.go
+++ b/helpers_key.go
@@ -20,7 +20,7 @@ import (
 var defaultKeyFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:        "sec",
-		Usage:       "secret key to sign the event, as nsec, ncryptsec or hex, or a bunker URL",
+		Usage:       "secret key to sign the event, as nsec, ncryptsec or hex, or a bunker URL, it is more secure to use the environment variable NOSTR_SECRET_KEY than this flag",
 		DefaultText: "the key '1'",
 		Aliases:     []string{"connect"},
 		Category:    CATEGORY_SIGNER,

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/sdk"
 	"github.com/nbd-wtf/go-nostr/sdk/hints/memoryh"
+	"github.com/fatih/color"
 )
 
 var version string = "debug"
@@ -118,8 +119,12 @@ var app = &cli.Command{
 }
 
 func main() {
+	defer func() {
+		color.New(color.Reset).Println()
+	}()
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		stdout(err)
+		color.New(color.Reset).Println()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
i'm not sure why your use of fatih/color isn't resetting the terminal mode but it was causing me to have issues with my default ubuntu terminal prompt somehow, i have used the library before and the color "Reset" means to turn off whatever has been turned on to default

this also includes a note in the help text regarding the environment variable for the auth key to use, it is very bad security to drop nsex into the terminal history, any process from the user can read these, and they appear in the task list/ps in the commandline field

i suppose it should also have a note in the readme but i think you can do that, i'm done here