### PR TITLE
Don't emit hello event if no events were received from stdin

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -75,7 +75,7 @@ func getJsonsOrBlank() iter.Seq[string] {
 			return true
 		})
 
-		if !hasStdin {
+		if !hasStdin && !isPiped() {
 			yield("{}")
 		}
 


### PR DESCRIPTION
When running `nak req ... relay.one | nak event relay.two`, if the first req doesn't return any events, the second nak should not publish a `"hello from nostr army knife"` note to `relay.two` as it is clearly not the intention.

`nak event relay.two` behavior is unchanged, it will publish the hello to `relay.two`
