### PR TITLE
Fix: docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.25-alpine AS builder
 
 # install git and ca-certificates (needed for fetching dependencies)
-RUN apk add --no-cache git ca-certificates gcc musl-dev lmdb-dev
+RUN apk add --no-cache git ca-certificates gcc musl-dev
 
 # set working directory
 WORKDIR /app


### PR DESCRIPTION
Hi,

**Problem**

the docker build was no longer working for me. First, I had to increase the go version to 1.25 as otherwise this error popped up:

```bash
 => ERROR [nak-relay builder 5/7] RUN go mod download                      0.1s
------
 > [nak-relay builder 5/7] RUN go mod download:
0.122 go: go.mod requires go >= 1.25 (running go 1.24.13; GOTOOLCHAIN=local)
```
After that, I ran into this error:
```
------
 > [nak-relay builder 7/7] RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o nak .:
0.629 github.com/PowerDNS/lmdb-go/lmdb: build constraints exclude all Go files in /go/pkg/mod/github.com/!power!d!n!s/lmdb-go@v1.9.3/lmdb
------
```
Which also errored.

**Solution**

Fixed it by bumping the go version and enabling CGO and and adding gcc and musl-dev packages. Not sure this is the best way but it seems to work again.

Closes https://github.com/fiatjaf/nak/issues/105