### PR TITLE
fix: remove incorrect '#' prefix from TagMap key in group forum filter

### DIFF
--- a/group.go
+++ b/group.go
@@ -378,7 +378,7 @@ var group = &cli.Command{
 
 				for evt := range sys.Pool.FetchMany(ctx, []string{relay}, nostr.Filter{
 					Kinds: []nostr.Kind{11},
-					Tags:  nostr.TagMap{"#h": []string{identifier}},
+					Tags:  nostr.TagMap{"h": []string{identifier}},
 				}, nostr.SubscriptionOptions{Label: "nak-nip29"}) {
 					title := evt.Tags.Find("title")
 					if title != nil {


### PR DESCRIPTION
The forum subcommand used "#h" as the TagMap key, but TagMap keys should not include the '#' prefix. All other TagMap usages in this file correctly use just the tag letter (e.g. "d", "h").