### PR TITLE
gift unwrap: add missing seal verification and rumor pubkey/ID correction

### DIFF
--- a/gift.go
+++ b/gift.go
@@ -236,6 +236,10 @@ a decoupled key (if it has been created or received with "nak dekey" previously)
 						return fmt.Errorf("not a seal event (kind %d)", seal.Kind)
 					}
 
+					if !seal.VerifySignature() {
+						return fmt.Errorf("seal signature is invalid")
+					}
+
 					senderEncryptionPublicKeys := []nostr.PubKey{seal.PubKey}
 					if theirEPub, exists := getDecoupledEncryptionPublicKey(ctx, seal.PubKey); exists {
 						senderEncryptionPublicKeys = append(senderEncryptionPublicKeys, seal.PubKey)

--- a/gift.go
+++ b/gift.go
@@ -275,6 +275,9 @@ a decoupled key (if it has been created or received with "nak dekey" previously)
 						return fmt.Errorf("failed to decrypt rumor: %w", err)
 					}
 
+					rumor.PubKey = seal.PubKey
+					rumor.ID = rumor.GetID()
+
 					// output the unwrapped event (rumor)
 					stdout(rumor.String())
 				}


### PR DESCRIPTION
## Summary

- Verify seal signature before trusting `seal.PubKey` for decryption key lookup
- Override rumor pubkey from the verified seal and recompute rumor ID

These three checks exist in `nip59.GiftUnwrap()` but were missing from the CLI `gift unwrap` path, which reimplements unwrapping inline.

## Why this matters

Without these checks:
- A forged seal with an invalid signature is silently accepted
- The rumor's self-declared pubkey is trusted, enabling sender impersonation (NIP-17: *"Clients MUST verify if pubkey of the `kind:13` is the same pubkey on the `kind:14`"*)
- The output event ID is inconsistent with its content

## Breaking change

Seals with invalid signatures that were previously silently accepted will now be rejected. This is correct per NIP-59 and matches the library behavior.

## Test plan

- [x] `go build` compiles cleanly
- [x] Existing tests unaffected (no gift wrap test coverage exists)

Fixes #110

Origin: [nostrability/nostrability#169 (comment)](https://github.com/nostrability/nostrability/issues/169#issuecomment-4017953483) — item 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)