### PR TITLE
fix: git init --owner reads empty string instead of flag value

### DIFF
--- a/git.go
+++ b/git.go
@@ -157,7 +157,7 @@ aside from those, there is also:
 				var owner nostr.PubKey
 				var ownerStr string
 				if c.String("owner") != "" {
-					owner, err = parsePubKey(ownerStr)
+					owner, err = parsePubKey(c.String("owner"))
 					if err != nil {
 						return fmt.Errorf("invalid owner pubkey: %w", err)
 					}


### PR DESCRIPTION
## Summary
- `nak git init --owner <pubkey>` always fails with `invalid pubkey ("")` because `parsePubKey(ownerStr)` uses the uninitialized local variable instead of `c.String("owner")`
- One-line fix: pass the actual flag value to the parser

Fixes #113

## Test plan
- `nak git init --identifier test --name test --owner <hex-or-npub>` should now write `nip34.json` with the correct owner field

🤖 Generated with [Claude Code](https://claude.com/claude-code)