### PR TITLE
fix: misspelling domain in git grasp servers

### DIFF
--- a/git.go
+++ b/git.go
@@ -281,7 +281,7 @@ aside from those, there is also:
 						"gitnostr.com",
 						"relay.ngit.dev",
 						"pyramid.fiatjaf.com",
-						"git.shakespeare.dyi",
+						"git.shakespeare.diy",
 					}, graspServerHost, nil)
 					if err != nil {
 						return err


### PR DESCRIPTION
Changed `git.shakespeare.dyi` to `git.shakespeare.diy` 