### PR TITLE
blossom: fix wrong source length in hex decode of download hash

### DIFF
--- a/blossom.go
+++ b/blossom.go
@@ -154,11 +154,11 @@ var blossomCmd = &cli.Command{
 				var hash [32]byte
 				for i, hhash := range c.Args().Slice() {
 					if len(hhash) != 64 {
-						log("invalid blob hash '%s': %s\n", hhash, err)
+						log("invalid blob hash '%s'\n", hhash)
 						hasError = true
 						continue
 					}
-					if _, err := hex.Decode(hash[:], unsafe.Slice(unsafe.StringData(hhash), 32)); err != nil {
+					if _, err := hex.Decode(hash[:], unsafe.Slice(unsafe.StringData(hhash), 64)); err != nil {
 						log("invalid blob hash '%s': %s\n", hhash, err)
 						hasError = true
 						continue


### PR DESCRIPTION
`hex.Decode` was being passed a 32-byte source for a 64-char hex string in the `blossom download` command, so only 16 bytes of the hash were filled and the rest carried stale data from the previous iteration. The first len-check log was also formatting a stale, out-of-scope `err`.