### PR TITLE
publish: avoid nil panic when --reply decodes to an unexpected type

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -91,6 +91,8 @@ example:
 					replyEvent, _, err = sys.FetchSpecificEvent(ctx, pointer, sdk.FetchSpecificEventParameters{})
 				case nostr.EntityPointer:
 					replyEvent, _, err = sys.FetchSpecificEvent(ctx, pointer, sdk.FetchSpecificEventParameters{})
+				default:
+					return fmt.Errorf("unexpected reply target type: %T", value)
 				}
 				if err != nil {
 					return fmt.Errorf("failed to fetch reply target event: %w", err)


### PR DESCRIPTION
The type switch on `nip19.Decode`'s value had no `default` branch, so if the decoded value was neither `EventPointer` nor `EntityPointer`, `replyEvent` stayed nil and the following `replyEvent.Kind` access panicked. Return an error in that case.