### PR TITLE
nsite: fix path traversal vulnerability in download command

### DIFF
--- a/nsite.go
+++ b/nsite.go
@@ -273,7 +273,11 @@ var nsite = &cli.Command{
 				signer := keyer.NewReadOnlySigner(pk)
 
 				for path, hash := range mnf.Paths {
-					fullPath := filepath.Join(outputDir, filepath.FromSlash(strings.TrimPrefix(path, "/")))
+					relPath := strings.TrimPrefix(path, "/")
+					if !filepath.IsLocal(relPath) {
+						return fmt.Errorf("manifest path %q escapes output directory", path)
+					}
+					fullPath := filepath.Join(outputDir, filepath.FromSlash(relPath))
 					if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 						return fmt.Errorf("failed to create %s: %w", filepath.Dir(fullPath), err)
 					}


### PR DESCRIPTION
A malicious or malformed nsite manifest could place arbitrary `..` segments in its paths, which were only stripped of a leading `/` before being joined with the user-supplied output directory. As a result `os.WriteFile` could be tricked into writing outside that directory — e.g. overwriting `~/.ssh/authorized_keys`, `~/.bashrc`, or other files in the user's home directory — just by getting them to download a hostile nsite. Use `filepath.IsLocal` to reject any non-local relative path before writing.