### PR TITLE
lmdb: invert configPath check to flatten setupLocalDatabases

### DIFF
--- a/lmdb.go
+++ b/lmdb.go
@@ -16,28 +16,30 @@ import (
 
 func setupLocalDatabases(c *cli.Command, sys *sdk.System) {
 	configPath := c.String("config-path")
-	if configPath != "" {
-		hintsPath := filepath.Join(configPath, "outbox/hints")
-		os.MkdirAll(hintsPath, 0755)
-		_, err := lmdbh.NewLMDBHints(hintsPath)
-		if err != nil {
-			log("failed to create lmdb hints db at '%s': %s\n", hintsPath, err)
-		}
+	if configPath == "" {
+		return
+	}
 
-		eventsPath := filepath.Join(configPath, "events")
-		os.MkdirAll(eventsPath, 0755)
-		sys.Store = &lmdb.LMDBBackend{Path: eventsPath}
-		if err := sys.Store.Init(); err != nil {
-			log("failed to create boltdb events db at '%s': %s\n", eventsPath, err)
-			sys.Store = &nullstore.NullStore{}
-		}
+	hintsPath := filepath.Join(configPath, "outbox/hints")
+	os.MkdirAll(hintsPath, 0755)
+	_, err := lmdbh.NewLMDBHints(hintsPath)
+	if err != nil {
+		log("failed to create lmdb hints db at '%s': %s\n", hintsPath, err)
+	}
 
-		kvPath := filepath.Join(configPath, "kvstore")
-		os.MkdirAll(kvPath, 0755)
-		if kv, err := lmdbkv.NewStore(kvPath); err != nil {
-			log("failed to create boltdb kvstore db at '%s': %s\n", kvPath, err)
-		} else {
-			sys.KVStore = kv
-		}
+	eventsPath := filepath.Join(configPath, "events")
+	os.MkdirAll(eventsPath, 0755)
+	sys.Store = &lmdb.LMDBBackend{Path: eventsPath}
+	if err := sys.Store.Init(); err != nil {
+		log("failed to create boltdb events db at '%s': %s\n", eventsPath, err)
+		sys.Store = &nullstore.NullStore{}
+	}
+
+	kvPath := filepath.Join(configPath, "kvstore")
+	os.MkdirAll(kvPath, 0755)
+	if kv, err := lmdbkv.NewStore(kvPath); err != nil {
+		log("failed to create boltdb kvstore db at '%s': %s\n", kvPath, err)
+	} else {
+		sys.KVStore = kv
 	}
 }


### PR DESCRIPTION
Invert the empty-`configPath` check into an early `return` so the rest of `setupLocalDatabases` sits at the function's top level. No behavior change.