### PR TITLE
req: actually decode bech32 values for single-letter --tag flags

### DIFF
--- a/req.go
+++ b/req.go
@@ -595,8 +595,8 @@ func applyFlagsToFilter(c *cli.Command, filter *nostr.Filter) error {
 		spl := strings.SplitN(tagFlag, "=", 2)
 		if len(spl) == 2 {
 			val := spl[1]
-			if len(spl) == 1 {
-				val = decodeTagValue(val, []rune(spl[0])[0])
+			if len(spl[0]) == 1 {
+				val = decodeTagValue(val, rune(spl[0][0]))
 			}
 			tags = append(tags, flagTag{spl[0], val})
 		} else {


### PR DESCRIPTION
The inner `if len(spl) == 1` inside the `len(spl) == 2` branch was unreachable, so `decodeTagValue` was never called for `--tag` values. Result: `nak req --tag e=nevent1...` did not decode while the shortcut `-e nevent1...` did. Check `len(spl[0]) == 1` (the tag-name length) instead, matching the analogous code in `event.go`.