### PR TITLE
sync: drain source then publish concurrently to avoid dropping events under load

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -78,9 +78,7 @@ var syncCmd = &cli.Command{
 
 				// every 30 ids do a fetch-and-publish
 				if len(pending[idx].ids) == 30 {
-					for evt := range pending[idx].src.QueryEvents(nostr.Filter{IDs: pending[idx].ids}) {
-						pending[idx].dst.Publish(ctx, evt)
-					}
+					fetchAndPublish(ctx, pending[idx].src, pending[idx].dst, pending[idx].ids)
 					pending[idx].ids = pending[idx].ids[:0]
 				}
 			}
@@ -88,9 +86,7 @@ var syncCmd = &cli.Command{
 			// do it for the remaining ids
 			for _, op := range pending {
 				if len(op.ids) > 0 {
-					for evt := range op.src.QueryEvents(nostr.Filter{IDs: op.ids}) {
-						op.dst.Publish(ctx, evt)
-					}
+					fetchAndPublish(ctx, op.src, op.dst, op.ids)
 				}
 			}
 		})
@@ -99,6 +95,35 @@ var syncCmd = &cli.Command{
 
 		return err
 	},
+}
+
+// fetchAndPublish drains every event from src, then publishes them to dst
+// concurrently. Two problems are avoided:
+//
+//  1. Publishing inline while ranging over QueryEvents lets a slow dst
+//     back-pressure the src subscription, so we drain src fully first.
+//  2. Publish blocks up to 7s per event waiting for an OK. Publishing
+//     sequentially makes total time scale with the number of events times that
+//     wait, so under load an outer deadline can cut the sync off with most
+//     events still unsent. Publishing concurrently overlaps the OK waits so the
+//     EVENT frames all leave promptly.
+//
+// Publish errors are surfaced rather than silently dropped.
+func fetchAndPublish(ctx context.Context, src, dst *nostr.Relay, ids []nostr.ID) {
+	events := make([]nostr.Event, 0, len(ids))
+	for evt := range src.QueryEvents(nostr.Filter{IDs: ids}) {
+		events = append(events, evt)
+	}
+
+	wg := sync.WaitGroup{}
+	for _, evt := range events {
+		wg.Go(func() {
+			if err := dst.Publish(ctx, evt); err != nil {
+				logverbose("failed to publish %s to %s: %s\n", evt.ID.Hex(), dst.URL, err)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 type ThirdPartyNegentropy struct {

--- a/sync.go
+++ b/sync.go
@@ -97,18 +97,19 @@ var syncCmd = &cli.Command{
 	},
 }
 
-// fetchAndPublish drains every event from src, then publishes them to dst
-// concurrently. Two problems are avoided:
+// fetchAndPublish drains every event from src before publishing to dst.
 //
-//  1. Publishing inline while ranging over QueryEvents lets a slow dst
-//     back-pressure the src subscription, so we drain src fully first.
-//  2. Publish blocks up to 7s per event waiting for an OK. Publishing
-//     sequentially makes total time scale with the number of events times that
-//     wait, so under load an outer deadline can cut the sync off with most
-//     events still unsent. Publishing concurrently overlaps the OK waits so the
-//     EVENT frames all leave promptly.
+// QueryEvents subscribes with go-nostr's default 7s MaxWaitForEOSE, an absolute
+// timer from subscription start. sub.Events is unbuffered, so once the timer
+// fires any event not yet handed to the consumer is dropped (the dispatch
+// goroutine takes its eoseTimedOut branch) and a fake EOSE ends the range. The
+// old loop published inline, and Publish blocks up to 7s per event waiting for
+// an OK, so under load the slow publish stalled the consumer, the source sub
+// hit its EOSE deadline, and the rest of the batch was silently discarded.
 //
-// Publish errors are surfaced rather than silently dropped.
+// Draining into a slice consumes every event within the EOSE window, then
+// publishes afterward. Publishing concurrently is a throughput bonus, not the
+// fix. Publish errors are surfaced rather than dropped.
 func fetchAndPublish(ctx context.Context, src, dst *nostr.Relay, ids []nostr.ID) {
 	events := make([]nostr.Event, 0, len(ids))
 	for evt := range src.QueryEvents(nostr.Filter{IDs: ids}) {


### PR DESCRIPTION
## Problem

`nak sync` silently drops events under load, leaving the destination with a subset of the source's events.

The cause is in the fetch-and-publish loop. `QueryEvents` subscribes with go-nostr's default 7s `MaxWaitForEOSE`, an absolute timer from subscription start. `sub.Events` is unbuffered, so once that timer fires any event not yet handed to the consumer is dropped (the dispatch goroutine takes its `eoseTimedOut` branch) and a fake EOSE ends the range.

The old loop published inline while ranging over `QueryEvents`, and `Publish` blocks up to 7s per event waiting for an OK. Under load the slow publish stalls the consumer, the source subscription hits its 7s EOSE deadline, and the rest of the 30-id batch is discarded. The `Publish` error was ignored too, so the loss was silent.

## Fix

`fetchAndPublish` drains the source into a slice first, so every event is consumed within the EOSE window, then publishes afterward. Publishing concurrently overlaps the per-event OK waits (throughput only, not the correctness fix). Publish errors are now surfaced via `logverbose`.

No behavior change on the normal uncontended path.
