### PR TITLE
key: fix combine crashing with unbounded recursion when no valid pubkeys are given

### DIFF
--- a/key.go
+++ b/key.go
@@ -310,6 +310,12 @@ However, if the intent is to check if two existing Nostr pubkeys match a given c
 
 				continue
 			}
+
+			return fmt.Errorf("invalid key %s: expected 32 or 33 bytes hex", keyhex)
+		}
+
+		if len(keyGroups) < 2 {
+			return fmt.Errorf("at least two pubkeys are required")
 		}
 
 		result.Combinations = make([]Combination, 0, 16)


### PR DESCRIPTION
`nak key combine` with no arguments (or with only unparseable ones) ended up with an empty keyGroups slice, so the recursive combination builder could never meet its termination condition and recursed forever, hanging at 100% CPU until killed.

Also, an argument that decoded as hex but wasn't a valid pubkey was silently dropped from the combinations while still being listed under "keys" in the output, producing misleading results.

Now unparseable keys are an error and at least two pubkeys are required.