### PR TITLE
dekey: don't keep a decrypted key that doesn't match the announced pubkey

### DIFF
--- a/dekey.go
+++ b/dekey.go
@@ -236,12 +236,14 @@ var dekey = &cli.Command{
 					if err != nil {
 						continue
 					}
-					eSec, err = nostr.SecretKeyFromHex(eSecHex)
+					candidate, err := nostr.SecretKeyFromHex(eSecHex)
 					if err != nil {
 						continue
 					}
-					// check if it matches mainPub
-					if eSec.Public() == ePub {
+					// check if it matches mainPub -- only keep it if it does, otherwise a
+					// stale key received from another device would end up being redistributed
+					if candidate.Public() == ePub {
+						eSec = candidate
 						log(color.GreenString("successfully received decoupled encryption key from another device\n"))
 						// store it
 						os.MkdirAll(filepath.Dir(eKeyPath), 0700)


### PR DESCRIPTION
When fetching the decoupled encryption key from other devices, the decrypted candidate was assigned to the outer eSec variable before being checked against the announced pubkey. If the loop ended without a match (for example a stale kind:4455 carrying an old, rotated-away key), that mismatched key survived the zero-value check, was reported as ready, and would then be encrypted and redistributed to all other announced devices.