### PR TITLE
publish: don't put the pubkey in the relay-hint position of NIP-22 E/e tags

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -263,11 +263,12 @@ func buildNIP22Tags(evt *nostr.Event, target *nostr.Event, relayHints []string) 
 
 	// root scope tag
 	rootScopeTag := nostr.Tag{rootScopeName, rootScopeValue}
-	if rootScopeRelay != "" {
-		rootScopeTag = append(rootScopeTag, rootScopeRelay)
-	}
 	if rootScopeName == "E" && rootPubkey != "" {
-		rootScopeTag = append(rootScopeTag, rootPubkey)
+		// the pubkey goes in the 4th position, so the relay hint must be
+		// present (even if empty) to keep it there
+		rootScopeTag = append(rootScopeTag, rootScopeRelay, rootPubkey)
+	} else if rootScopeRelay != "" {
+		rootScopeTag = append(rootScopeTag, rootScopeRelay)
 	}
 	evt.Tags = append(evt.Tags, rootScopeTag)
 
@@ -295,11 +296,11 @@ func buildNIP22Tags(evt *nostr.Event, target *nostr.Event, relayHints []string) 
 			evt.Tags = append(evt.Tags, aTag)
 		}
 		eTag := nostr.Tag{"e", target.ID.Hex()}
-		if relayHint != "" {
-			eTag = append(eTag, relayHint)
-		}
 		if target.PubKey != (nostr.PubKey{}) {
-			eTag = append(eTag, target.PubKey.Hex())
+			// same here: keep the pubkey in the 4th position
+			eTag = append(eTag, relayHint, target.PubKey.Hex())
+		} else if relayHint != "" {
+			eTag = append(eTag, relayHint)
 		}
 		evt.Tags = append(evt.Tags, eTag)
 	}


### PR DESCRIPTION
When there was no relay hint, buildNIP22Tags appended the pubkey right after the event id, so it landed in the relay-hint position. Parsers like nostr.EventPointerFromTag read position 2 as the relay URL and position 3 as the author, so the author was lost and the pubkey could even be treated as a relay URL. Now an empty relay-hint placeholder is kept when the pubkey is present.