### PR TITLE
event: reset tags with [:0] instead of clear() between stdin events

### DIFF
--- a/event.go
+++ b/event.go
@@ -206,7 +206,7 @@ example:
 		handleEvent := func(stdinEvent string) error {
 			evt.Content = ""
 			evt.CreatedAt = 0
-			clear(evt.Tags)
+			evt.Tags = evt.Tags[:0]
 			evt.ID = nostr.ZeroID
 			evt.PubKey = nostr.ZeroPK
 			evt.Sig = [64]byte{}


### PR DESCRIPTION
clear() on a slice nils the elements but keeps the length, and easyjson only resets Tags when the incoming JSON actually has a "tags" key. So when processing multiple events from stdin, an event without "tags" inherited the previous event's tag slots as phantom empty tags, which got hashed, signed and published (e.g. "tags":[[],[]]).