### PR TITLE
curl: fix completely broken command

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -20,6 +20,9 @@ var curl = &cli.Command{
 	Usage:                     "calls curl but with a nip98 header",
 	Description:               "accepts all flags and arguments exactly as they would be passed to curl.",
 	DisableSliceFlagSeparator: true,
+	// this command is always run standalone (see realCurl()), never under the root
+	// command, so it needs its own copy of the key flags
+	Flags: defaultKeyFlags,
 	Action: func(ctx context.Context, c *cli.Command) error {
 		kr, _, err := gatherKeyerFromArguments(ctx, c)
 		if err != nil {
@@ -129,5 +132,6 @@ func realCurl() error {
 		}
 	}
 
-	return curl.Run(context.Background(), keyFlags)
+	// Run treats the first element as the program name, so prepend one
+	return curl.Run(context.Background(), append([]string{"nak curl"}, keyFlags...))
 }


### PR DESCRIPTION
Since the key flags moved to the root command (0c8e643), `nak curl` always failed with "invalid secret key": main() intercepts curl and calls the command directly through realCurl(), bypassing the root command, so the persistent key flags never existed there and c.String("sec") was always empty. On top of that, curl.Run() treats the first element of its argument slice as the program name, so the first extracted key flag was being swallowed. The command now carries its own copy of the key flags and a program name is prepended before Run.