### PR TITLE
blossom: fix check truncating hashes to 32 chars

### DIFF
--- a/blossom.go
+++ b/blossom.go
@@ -238,8 +238,9 @@ if any of the files are not found the command will fail, otherwise it will succe
 
 				hasError := false
 				for _, hash := range c.Args().Slice() {
-					if len(hash) > 32 {
-						hash = hash[0:32]
+					// a sha256 is 64 hex characters, anything after that is an extension
+					if len(hash) > 64 {
+						hash = hash[0:64]
 					}
 
 					err := client.Check(ctx, hash)


### PR DESCRIPTION
The truncation added in 4ea0edc cut hashes down to 32 characters, but a sha256 in hex is 64, so every valid hash was truncated to half and then rejected by the client's IsValid32ByteHex validation before any request was made — the command failed on all correct inputs. Truncate at 64 instead, which keeps the apparent intent of stripping a file extension.