### PR TITLE
fetch: fix panic on note1 codes

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -74,7 +74,7 @@ var fetch = &cli.Command{
 					}
 					relays = append(relays, v.Relays...)
 				case "note":
-					filter.IDs = append(filter.IDs, value.([32]byte))
+					filter.IDs = append(filter.IDs, value.(nostr.EventPointer).ID)
 				case "naddr":
 					v := value.(nostr.EntityPointer)
 					filter.Kinds = []nostr.Kind{v.Kind}


### PR DESCRIPTION
nip19.Decode returns a nostr.EventPointer for note codes, but fetch asserted the value as a bare [32]byte, so `nak fetch note1...` panicked with an interface conversion error on any note input.