### PR TITLE
sync: close the Deltas channel on error returns too

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -204,6 +204,9 @@ func NewThirdPartyNegentropy(peerA, peerB *RelayThirdPartyRemote, filter nostr.F
 }
 
 func (n *ThirdPartyNegentropy) Run(ctx context.Context) error {
+	// always close Deltas so the consumer goroutine doesn't hang when we return an error
+	defer close(n.Deltas)
+
 	peerAIds := make(map[nostr.ID]struct{})
 	peerBIds := make(map[nostr.ID]struct{})
 	peerASkippedBounds := make(map[boundKey]struct{})
@@ -341,7 +344,6 @@ func (n *ThirdPartyNegentropy) Run(ctx context.Context) error {
 
 	n.PeerA.SendClose()
 	n.PeerB.SendClose()
-	close(n.Deltas)
 
 	return nil
 }


### PR DESCRIPTION
Run() only closed tpn.Deltas on its success path, so any error return (a failed write, a malformed message, a NEG-ERR) left the publisher goroutine blocked in `range tpn.Deltas` forever and wg.Wait() never returned — `nak sync` just hung instead of reporting the error. The close is now deferred.