### PR TITLE
helpers: guard shared state in connectToAllRelays with a mutex

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -219,21 +219,28 @@ func connectToAllRelays(
 
 		wg := sync.WaitGroup{}
 		wg.Add(len(relayUrls))
+		mu := sync.Mutex{} // guards lines and relays, written from the goroutines below
 		for i, url := range relayUrls {
 			lines[i] = make([][]byte, 1, 2)
 			logthis := func(s string, args ...any) {
+				mu.Lock()
 				lines[i] = append(lines[i], []byte(fmt.Sprintf(s, args...)))
 				render()
+				mu.Unlock()
 			}
 			colorizepreamble := func(c func(string, ...any) string) {
+				mu.Lock()
 				lines[i][0] = []byte(fmt.Sprintf("%s... ", c(url)))
+				mu.Unlock()
 			}
 			colorizepreamble(color.CyanString)
 
 			go func() {
 				relay := connectToSingleRelay(ctx, c, url, colorizepreamble, logthis)
 				if relay != nil {
+					mu.Lock()
 					relays = append(relays, relay)
+					mu.Unlock()
 				}
 				wg.Done()
 			}()


### PR DESCRIPTION
In the dynamic multiline path, one goroutine per relay appended to the shared relays slice with no synchronization, so two simultaneous appends could lose a successfully connected relay (events then silently not published to / queried from it). The per-line log buffers were also written and rendered concurrently. Both are now guarded by a mutex.