### PR TITLE
event: don't leak --outbox relays across stdin events

### DIFF
--- a/event.go
+++ b/event.go
@@ -185,7 +185,7 @@ example:
 	),
 	ArgsUsage: "[relay...]",
 	Action: func(ctx context.Context, c *cli.Command) error {
-		relayUrls := c.Args().Slice()
+		argRelayUrls := c.Args().Slice()
 
 		kr, sec, err := gatherKeyerFromArguments(ctx, c)
 		if err != nil {
@@ -383,6 +383,9 @@ example:
 			}
 
 			var relays []*nostr.Relay
+			// start from the given relays on every event so --outbox additions
+			// for one event don't leak into the next
+			relayUrls := slices.Clone(argRelayUrls)
 			if len(relayUrls) > 0 || c.Bool("outbox") {
 				if c.Bool("outbox") {
 					if evt.PubKey != nostr.ZeroPK {


### PR DESCRIPTION
The relay URL list was a single variable shared by all events read from stdin, and the --outbox branch kept appending to it, so the write relays of event 1's author and the inbox relays of its p-tagged pubkeys leaked into the publish targets of every subsequent event. Each event now starts from a fresh copy of the relays given as arguments.