### PR TITLE
verify, validate: fix the blank-stdin sentinel check

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -51,7 +51,8 @@ nak event -k 1 -p not_a_pubkey | nak validate
 		}
 
 		for stdinEvent := range getJsonsOrBlank() {
-			if stdinEvent == "" {
+			if stdinEvent == "{}" && !isPiped() {
+				// blank sentinel from getJsonsOrBlank(), use the arguments instead
 				for _, arg := range c.Args().Slice() {
 					if err := handleEvent(arg); err != nil {
 						ctx = lineProcessingError(ctx, "%s", err)

--- a/verify.go
+++ b/verify.go
@@ -19,7 +19,8 @@ it outputs nothing if the verification is successful.`,
 	Action: func(ctx context.Context, c *cli.Command) error {
 		for stdinEvent := range getJsonsOrBlank() {
 			evt := nostr.Event{}
-			if stdinEvent == "" {
+			if stdinEvent == "{}" && !isPiped() {
+				// blank sentinel from getJsonsOrBlank(), use the argument instead
 				stdinEvent = c.Args().First()
 				if stdinEvent == "" {
 					continue


### PR DESCRIPTION
Both commands compared the stdin value against "" to decide whether to fall back to their arguments, but getJsonsOrBlank() yields "{}" when there is no stdin, so the argument forms never worked: `nak verify '<event json>'` validated an empty event and always failed, and `nak validate '<event json>'` validated the empty sentinel instead of the argument. They now check for the "{}" sentinel (like spell.go does) plus isPiped().