### PR TITLE
key: fix decrypt never reading the ncryptsec from stdin

### DIFF
--- a/key.go
+++ b/key.go
@@ -173,7 +173,8 @@ var decryptKey = &cli.Command{
 				}
 			} else {
 				password = c.Args().Get(0)
-				for ncryptsec := range getStdinLinesOrArgumentsFromSlice([]string{ncryptsec}) {
+				// the ncryptsec codes come from stdin
+				for ncryptsec := range getStdinLinesOrArgumentsFromSlice(nil) {
 					sk, err := nip49.Decrypt(ncryptsec, password)
 					if err != nil {
 						ctx = lineProcessingError(ctx, "failed to decrypt: %s", err)
@@ -181,6 +182,7 @@ var decryptKey = &cli.Command{
 					}
 					stdout(sk.Hex())
 				}
+				exitIfLineProcessingError(ctx)
 				return nil
 			}
 		default:


### PR DESCRIPTION
In the one-argument form (`echo ncryptsec1... | nak key decrypt <password>`) the code passed a slice containing the empty ncryptsec variable to getStdinLinesOrArgumentsFromSlice, which sees a non-empty args slice and never consults stdin — so it tried to decrypt an empty string, logged a failure, and still exited 0 since the line-processing error was never checked. It now reads from stdin and exits non-zero on failure.