### PR TITLE
git: fix nil dereference in pull when the repository has no published state

### DIFF
--- a/git.go
+++ b/git.go
@@ -853,7 +853,7 @@ aside from those, there is also:
 				}
 
 				// get the commit from state for the remote branch
-				if state.Event.ID == nostr.ZeroID {
+				if state == nil || state.Event.ID == nostr.ZeroID {
 					return fmt.Errorf("no repository state found")
 				}
 


### PR DESCRIPTION
gitSync returns a nil state with no error when the announcement exists but no kind:30618 state event was ever published, and pull dereferenced it in the very check that was supposed to print "no repository state found" — so it panicked instead of showing the error.