### PR TITLE
git: don't panic in graspServerHost on empty or unparseable URLs

### DIFF
--- a/git.go
+++ b/git.go
@@ -2871,5 +2871,10 @@ func rebuildGraspURLFromRemote(remoteName string) string {
 }
 
 func graspServerHost(s string) string {
-	return strings.SplitN(nostr.NormalizeURL(s), "/", 3)[2]
+	// NormalizeURL returns "" for empty or unparseable inputs
+	parts := strings.SplitN(nostr.NormalizeURL(s), "/", 3)
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[2]
 }


### PR DESCRIPTION
nostr.NormalizeURL returns "" for empty or unparseable input, and graspServerHost indexed [2] into the result of splitting that on "/" — an index out of range. Since readNip34ConfigFile calls it on every grasp-servers entry of the user-edited nip34.json, a single stray or malformed entry crashed every nak git subcommand instead of surfacing a config error.