### PR TITLE
count: don't ignore EnsureRelay errors

### DIFF
--- a/count.go
+++ b/count.go
@@ -63,7 +63,13 @@ var count = &cli.Command{
 					hll = hyperloglog.New(offset)
 				}
 				for _, relayUrl := range relayUrls {
-					relay, _ := sys.Pool.EnsureRelay(relayUrl)
+					relay, err := sys.Pool.EnsureRelay(relayUrl)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "%s%s: ", strings.Repeat(" ", biggerUrlSize-len(relayUrl)), relayUrl)
+						fmt.Fprintf(os.Stderr, "error: %s\n", err)
+						continue
+					}
+
 					count, hllRegisters, err := relay.Count(ctx, filter, nostr.SubscriptionOptions{
 						Label: "nak-count",
 					})


### PR DESCRIPTION
Pool.EnsureRelay returns a nil relay on failure (reconnection failed, relay in the penalty box) and the error was discarded, so relay.Count panicked on a nil receiver — e.g. when a relay that connected at startup drops its connection between COUNT iterations. The error is now reported like other per-relay failures.