### PR TITLE
podcast: fix panic on note1 targets

### DIFF
--- a/podcast.go
+++ b/podcast.go
@@ -157,8 +157,7 @@ func resolvePodcastEpisode(ctx context.Context, target string, relayHints []stri
 			pointer := value.(nostr.EventPointer)
 			return fetchSpecificPodcastEpisode(ctx, pointer, relayHints)
 		case "note":
-			pointer := nostr.EventPointer{ID: value.(nostr.ID)}
-			return fetchSpecificPodcastEpisode(ctx, pointer, relayHints)
+			return fetchSpecificPodcastEpisode(ctx, value.(nostr.EventPointer), relayHints)
 		}
 	}
 


### PR DESCRIPTION
nip19.Decode returns a nostr.EventPointer for note codes, not a nostr.ID, so `nak podcast play note1...` panicked on the type assertion. Same family as the fetch fix in #157.