### PR TITLE
key: fix panic in validate with npub input

### DIFF
--- a/key.go
+++ b/key.go
@@ -214,7 +214,7 @@ Returns error if key is invalid, otherwise exits successfully.`,
 					ctx = lineProcessingError(ctx, "invalid npub: %s", err)
 					continue
 				}
-				tmp := data.([32]byte)
+				tmp := data.(nostr.PubKey)
 				pkBytes = tmp[:]
 			} else {
 				pkBytes, err = hex.DecodeString(pk)


### PR DESCRIPTION
nip19.Decode returns a nostr.PubKey for npub codes, and the assertion to a bare [32]byte fails because type identity matters for assertions — so `nak key validate npub1...` panicked on any npub, valid or not.