### PR TITLE
blossom: write downloaded blob bytes raw to stdout

### DIFF
--- a/blossom.go
+++ b/blossom.go
@@ -179,7 +179,7 @@ var blossomCmd = &cli.Command{
 							hasError = true
 							continue
 						}
-						stdout(data)
+						os.Stdout.Write(data)
 					}
 				}
 


### PR DESCRIPTION
Without --output the downloaded blob went through the Fprintln-based stdout helper, which formats a []byte as a decimal number array (like [104 101 108 108 111]) instead of writing the content, making the documented print-to-stdout mode useless. The bytes are now written raw to os.Stdout.