### PR TITLE
helpers: fix parseEventID rejecting note1 codes

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -507,8 +507,8 @@ func parseEventID(value string) (nostr.ID, error) {
 	if prefix, decoded, err := nip19.Decode(value); err == nil {
 		switch prefix {
 		case "note":
-			if id, ok := decoded.(nostr.ID); ok {
-				return id, nil
+			if event, ok := decoded.(nostr.EventPointer); ok {
+				return event.ID, nil
 			}
 		case "nevent":
 			if event, ok := decoded.(nostr.EventPointer); ok {


### PR DESCRIPTION
The note branch asserted the decoded value as nostr.ID, but nip19.Decode returns a nostr.EventPointer for note codes, so the assertion always failed and note1 inputs were rejected everywhere parseEventID is used (`nak encode nevent note1...`, the -i filter flag, etc.) despite being an advertised input format.