### PR TITLE
helpers: reject kind numbers above 65535

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -627,6 +627,9 @@ func getSchema() (schema.Schema, error) {
 
 func stringToKind(value string) (nostr.Kind, error) {
 	if n, err := strconv.Atoi(value); err == nil && n >= 0 {
+		if n > 65535 {
+			return 0, fmt.Errorf("kind number %d is out of range (0-65535)", n)
+		}
 		return nostr.Kind(n), nil
 	}
 


### PR DESCRIPTION
stringToKind converted any non-negative integer straight to the uint16-backed nostr.Kind, silently truncating out-of-range values — `nak event -k 65537` produced a signed kind:1 event and `nak kind 65537` showed info for kind 1. Out-of-range numbers are now an error.