### PR TITLE
filter: merge kind from the base event too

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -86,6 +86,9 @@ example:
 			if evt.Sig == [64]byte{} {
 				evt.Sig = baseEvent.Sig
 			}
+			if evt.Kind == 0 {
+				evt.Kind = baseEvent.Kind
+			}
 			if evt.Content == "" {
 				evt.Content = baseEvent.Content
 			}


### PR DESCRIPTION
The stdin/base-event merge copied every field except Kind, so when the event came from the argument (`nak filter '{"kind": 1, ...}' -k 1`) the kind stayed 0 and kind filters matched the wrong way around — the command's own documented example printed nothing while the inverted filter matched.