### PR TITLE
git: init --interactive was discarding the prompted identifier and owner

### DIFF
--- a/git.go
+++ b/git.go
@@ -246,11 +246,12 @@ aside from those, there is also:
 				}
 
 				// override with flags and existing config
-				config.Identifier = getValue(existingConfig.Identifier, c.String("identifier"), config.Identifier)
+				// (identifier and ownerStr already hold the flag value, the interactive answer or the default)
+				config.Identifier = identifier
 				config.Name = getValue(existingConfig.Name, c.String("name"), config.Name)
 				config.Description = getValue(existingConfig.Description, c.String("description"), config.Description)
 				config.Web = getSliceValue(existingConfig.Web, c.StringSlice("web"), config.Web)
-				config.Owner = getValue(existingConfig.Owner, c.String("owner"), config.Owner)
+				config.Owner = ownerStr
 				config.GraspServers = getSliceValue(existingConfig.GraspServers, c.StringSlice("grasp-servers"), config.GraspServers)
 				config.EarliestUniqueCommit = getValue(existingConfig.EarliestUniqueCommit, c.String("earliest-unique-commit"), config.EarliestUniqueCommit)
 				maintainers := getSliceValue(existingConfig.Maintainers, c.StringSlice("maintainers"), config.Maintainers)


### PR DESCRIPTION
When nip34.json already existed, the final flag/config merge preferred the existing values over anything not passed as a flag, so the identifier and owner the user just typed at the interactive prompts were silently thrown away — even though the error message for an existing config explicitly points users at --interactive "to update". The merge now uses the variables that already hold the flag value, the interactive answer or the default.