### PR TITLE
mcp: apply a default limit of 10 to search_profile

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -155,6 +155,9 @@ var mcpServer = &cli.Command{
 		), func(ctx context.Context, r mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			name := required[string](r, "name")
 			limit, _ := optional[float64](r, "limit")
+			if limit == 0 {
+				limit = 10
+			}
 
 			res := strings.Builder{}
 			res.Grow(500)


### PR DESCRIPTION
search_profile issued a filter with no limit, so a single query could pull an unbounded number of kind-0 events from the relay. Default the limit to 10 like the other search tools.