### PR TITLE
relay: exit with an error code when fetching the information document fails

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -31,6 +31,7 @@ var relay = &cli.Command{
 			pretty, _ := json.MarshalIndent(info, "", "  ")
 			stdout(string(pretty))
 		}
+		exitIfLineProcessingError(ctx)
 		return nil
 	},
 }


### PR DESCRIPTION
The relay command recorded line-processing errors but never called exitIfLineProcessingError, so failures to fetch a NIP-11 document still exited with status 0. Call it like the other line-processing commands do.