### PR TITLE
git: fix dead symref resolution branch in download

### DIFF
--- a/git.go
+++ b/git.go
@@ -590,8 +590,8 @@ aside from those, there is also:
 							commitHash = ch
 						} else if ch, ok := info.Refs["refs/tags/"+ref]; ok {
 							commitHash = ch
-						} else if sr, ok := info.Symrefs[ref]; ok && ch != "" {
-							commitHash, _ = info.Refs[sr]
+						} else if sr, ok := info.Symrefs[ref]; ok {
+							commitHash = info.Refs[sr]
 						}
 					}
 


### PR DESCRIPTION
The symref fallback in git download tested the always-empty ch variable instead of the ok result of the symref lookup, so the branch could never trigger. Test the lookup result instead.