### PR TITLE
git: don't write a literal '-' file after download printed to stdout

### DIFF
--- a/git.go
+++ b/git.go
@@ -635,9 +635,10 @@ aside from those, there is also:
 
 					if outputPath == "-" {
 						if _, err = os.Stdout.Write(obj.Data); err != nil {
-							log("\nprinted object %s to stdout\n", color.CyanString(obj.Hash))
 							return err
 						}
+						log("\nprinted object %s to stdout\n", color.CyanString(obj.Hash))
+						return nil
 					}
 
 					if err := os.WriteFile(outputPath, obj.Data, 0644); err != nil {


### PR DESCRIPTION
When git download was given -O -, it printed the object to stdout but then fell through and also wrote a file literally named '-'. Return after the stdout path instead.