### PR TITLE
mcp: separate the pubkey and content lines in read_events_from_relay output

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -242,7 +242,7 @@ var mcpServer = &cli.Command{
 			for ie := range events {
 				result.WriteString("author public key: ")
 				result.WriteString(ie.PubKey.Hex())
-				result.WriteString("content: '")
+				result.WriteString("\ncontent: '")
 				result.WriteString(ie.Content)
 				result.WriteString("'")
 				result.WriteString("\n---\n")


### PR DESCRIPTION
The output format string was missing a newline between the pubkey and content fields, so the two lines came out fused together.