### PR TITLE
admin: close the response body and don't use it as a format string

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -132,6 +132,7 @@ var admin = &cli.Command{
 							continue
 						}
 						b, err := io.ReadAll(resp.Body)
+						resp.Body.Close()
 						if err != nil {
 							log("failed to read response: %s\n", err)
 							continue
@@ -142,7 +143,7 @@ var admin = &cli.Command{
 							if len(bodyPrintable) > 300 {
 								bodyPrintable = bodyPrintable[0:297] + "..."
 							}
-							log(bodyPrintable)
+							log("%s", bodyPrintable)
 							continue
 						}
 						var response nip86.Response
@@ -152,10 +153,9 @@ var admin = &cli.Command{
 							if len(bodyPrintable) > 300 {
 								bodyPrintable = bodyPrintable[0:297] + "..."
 							}
-							log(bodyPrintable)
+							log("%s", bodyPrintable)
 							continue
 						}
-						resp.Body.Close()
 
 						// print the result
 						log("\n")


### PR DESCRIPTION
The HTTP response body was leaked on error paths, and its contents were passed directly as a format string so a '%' in the relay response would garble the output. Close the body with defer and log it via %s.