### PR TITLE
gift, dekey: fix key-mismatch error wrapping a nil err with %w

### DIFF
--- a/dekey.go
+++ b/dekey.go
@@ -164,7 +164,7 @@ var dekey = &cli.Command{
 					return fmt.Errorf("invalid main key: %w", err)
 				}
 				if eSec.Public() != ePub {
-					return fmt.Errorf("stored decoupled encryption key is corrupted: %w", err)
+					return fmt.Errorf("stored decoupled encryption key at %s doesn't match the announced key %s", eKeyPath, ePub.Hex())
 				}
 			} else {
 				log("- decoupled encryption key not found locally, attempting to fetch the key from other devices\n")

--- a/gift.go
+++ b/gift.go
@@ -332,7 +332,7 @@ func getDecoupledEncryptionSecretKey(ctx context.Context, configPath string, pub
 				return [32]byte{}, true, fmt.Errorf("invalid main key: %w", err)
 			}
 			if eSec.Public() != ePub {
-				return [32]byte{}, true, fmt.Errorf("stored decoupled encryption key is corrupted: %w", err)
+				return [32]byte{}, true, fmt.Errorf("stored decoupled encryption key at %s doesn't match the announced key %s", eKeyPath, ePub.Hex())
 			}
 			return eSec, true, nil
 		}


### PR DESCRIPTION
The key-mismatch error message wrapped a nil error with %w, producing a mangled '%!w(<nil>)' in the output. Drop the nil wrap and state the mismatch directly.