### PR TITLE
event: return non-zero exit when publishing to all relays fails

### DIFF
--- a/event.go
+++ b/event.go
@@ -588,6 +588,10 @@ func publishFlow(ctx context.Context, c *cli.Command, kr nostr.Signer, evt nostr
 		if len(successRelays) > 0 && c.Bool("nevent") {
 			log(nip19.EncodeNevent(evt.ID, successRelays, evt.PubKey) + "\n")
 		}
+
+		if len(successRelays) == 0 {
+			return fmt.Errorf("failed to publish to any of the %d relay(s) given", len(relays))
+		}
 	}
 
 	return nil

--- a/publish_flow_test.go
+++ b/publish_flow_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"fiatjaf.com/nostr"
+	"fiatjaf.com/nostr/khatru"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+// newTestRelay starts a local, in-process relay whose acceptance of events is
+// controlled by accept. The websocket connection itself always succeeds; what
+// varies is whether EVENTs are stored or rejected with an OK false.
+func newTestRelay(t *testing.T, accept bool) string {
+	t.Helper()
+
+	relay := khatru.NewRelay()
+	if accept {
+		relay.OnEvent = func(ctx context.Context, event nostr.Event) (reject bool, msg string) {
+			return false, ""
+		}
+		relay.StoreEvent = func(ctx context.Context, event nostr.Event) error { return nil }
+	} else {
+		relay.OnEvent = func(ctx context.Context, event nostr.Event) (reject bool, msg string) {
+			return true, "restricted: this test relay rejects everything"
+		}
+	}
+
+	server := httptest.NewServer(relay)
+	t.Cleanup(server.Close)
+
+	return "ws" + strings.TrimPrefix(server.URL, "http")
+}
+
+func connectTestRelay(t *testing.T, url string) *nostr.Relay {
+	t.Helper()
+
+	r, err := nostr.RelayConnect(t.Context(), url, nostr.RelayOptions{})
+	require.NoError(t, err, "test relay should always accept the websocket connection")
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+
+func signedTestEvent(t *testing.T) nostr.Event {
+	t.Helper()
+
+	sec, err := nostr.SecretKeyFromHex("0000000000000000000000000000000000000000000000000000000000000b")
+	require.NoError(t, err)
+
+	evt := nostr.Event{
+		Kind:      1,
+		Content:   "hello",
+		CreatedAt: nostr.Now(),
+	}
+	require.NoError(t, evt.Sign(sec))
+	return evt
+}
+
+// TestPublishFlowFailsWhenAllRelaysRejectEvent is a regression test for
+// https://github.com/fiatjaf/nak/issues/129 : if relays were given and every
+// single one of them rejects the event (connection succeeds, publish fails),
+// publishFlow must return a non-nil error so callers (and ultimately the
+// process exit code) reflect the failure instead of silently reporting success.
+func TestPublishFlowFailsWhenAllRelaysRejectEvent(t *testing.T) {
+	relayURL := newTestRelay(t, false)
+	relay := connectTestRelay(t, relayURL)
+	evt := signedTestEvent(t)
+
+	err := publishFlow(t.Context(), &cli.Command{}, nil, evt, []*nostr.Relay{relay})
+	require.Error(t, err, "publishing to a relay that rejects the event should return an error")
+	require.Contains(t, err.Error(), "failed to publish")
+}
+
+// TestPublishFlowSucceedsWhenARelayAcceptsEvent makes sure the fix for #129
+// didn't turn a successful publish into a reported failure.
+func TestPublishFlowSucceedsWhenARelayAcceptsEvent(t *testing.T) {
+	relayURL := newTestRelay(t, true)
+	relay := connectTestRelay(t, relayURL)
+	evt := signedTestEvent(t)
+
+	err := publishFlow(t.Context(), &cli.Command{}, nil, evt, []*nostr.Relay{relay})
+	require.NoError(t, err)
+}
+
+// TestPublishFlowNoRelaysIsNotAnError makes sure that calling publishFlow with
+// no relays at all (e.g. `nak event` with no relay arguments, just printing
+// the event) still doesn't produce a spurious error.
+func TestPublishFlowNoRelaysIsNotAnError(t *testing.T) {
+	evt := signedTestEvent(t)
+
+	err := publishFlow(t.Context(), &cli.Command{}, nil, evt, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #129.

## Problem

`nak event <relay...>` prints and signs the event fine, but currently
exits with status `0` even when *every* given relay rejects the
publish (e.g. all respond with `OK false`). `publishFlow()` already
tracks `successRelays`, it just never checks it before returning, so
a total failure to deliver was indistinguishable from success at the
process level — which breaks operator scripts that rely on the exit
code as a delivery signal (as described in the issue).

## Fix

In `publishFlow`, after the publish loop, if one or more relays were
given and `len(successRelays) == 0`, return an error instead of `nil`.

This is a minimal, localized change:
- `nak event`'s stdin-processing loop already turns any `handleEvent`
  error into a non-zero exit (`os.Exit(123)`) via the existing
  `lineProcessingError` / `exitIfLineProcessingError` mechanism, so
  this now kicks in correctly.
- `publishFlow` is also used by `publish`, `nsite`, and `dekey`, and
  all of those call sites already do `if err := publishFlow(...); err
  != nil { return err }`, so they get the same non-zero-exit behavior
  automatically and consistently, for free.
- Success (at least one relay accepts) and the "no relays given, just
  print the event" case are both unaffected — only "relays were given
  and all of them rejected" now surfaces as an error.

## QA / how I verified it

- Added `publish_flow_test.go` with unit tests that spin up a local,
  in-process relay using `khatru` (already a transitive dependency via
  `fiatjaf.com/nostr`) and call `publishFlow` directly:
  - a relay that rejects every event → `publishFlow` now returns an
    error containing "failed to publish"
  - a relay that accepts the event → still returns `nil` (no
    regression on the success path)
  - no relays passed at all → still returns `nil`
  - `go test ./... -run TestPublishFlow -v` passes.
- Also manually built the real `nak` binary and ran
  `nak event --sec ... -k 1 -c hello ws://127.0.0.1:<port>` against a
  local relay configured to reject the event (mirroring the repro
  steps from #129) and confirmed the process now exits non-zero
  instead of `0`; ran it again against an accepting relay and
  confirmed it still exits `0`. (This manual check isn't part of the
  committed diff, just how I convinced myself end-to-end before
  opening this PR.)
- `go build .` and `go vet .` are clean. (Note: on Windows this
  requires `CGO_ENABLED=0` in general, since `fs_windows.go` pulls in
  `cgofuse`/WinFsp which isn't relevant to this change — unrelated to
  this fix.)
- I did not touch the "connect to relay" path (`connectToAllRelays`,
  which already `os.Exit(3)`s if it can't connect to *any* relay at
  all) — this fix only covers the case where the connection succeeds
  but the relay(s) subsequently reject the event.

## Disclosure

I used an AI coding assistant (Claude) to help investigate and
implement this fix. I read through `publishFlow` and its call sites
myself, and ran the build/vet/tests locally as described above before
opening this PR.