### PR TITLE
zero out secret key bytes from memory as soon as they are no longer needed

### DIFF
--- a/bunker.go
+++ b/bunker.go
@@ -192,6 +192,10 @@ var bunker = &cli.Command{
 
 		// decrypt key here if necessary
 		var sec nostr.SecretKey
+		// this key is used for the whole bunker session (potentially
+		// long-running), so we can only wipe it once the command actually
+		// returns (e.g. on shutdown)
+		defer zero(sec[:])
 		if config.Secret.Plain != nil {
 			sec = *config.Secret.Plain
 		} else {

--- a/decode.go
+++ b/decode.go
@@ -45,6 +45,7 @@ var decode = &cli.Command{
 				switch v := data.(type) {
 				case nostr.SecretKey:
 					stdout(v.Hex())
+					zero(v[:])
 					continue
 				case nostr.PubKey:
 					stdout(v.Hex())

--- a/dekey.go
+++ b/dekey.go
@@ -66,6 +66,7 @@ var dekey = &cli.Command{
 		// check if we already have a local-device secret key
 		deviceKeyPath := filepath.Join(configPath, "dekey", "device-key")
 		var deviceSec nostr.SecretKey
+		defer zero(deviceSec[:])
 		if data, err := os.ReadFile(deviceKeyPath); err == nil {
 			log(color.GreenString("found existing device key\n"))
 			deviceSec, err = nostr.SecretKeyFromHex(string(data))
@@ -99,6 +100,7 @@ var dekey = &cli.Command{
 			Authors: []nostr.PubKey{userPub},
 		}, nostr.SubscriptionOptions{Label: "nak-nip4e"})
 		var eSec nostr.SecretKey
+		defer zero(eSec[:])
 		var ePub nostr.PubKey
 
 		var generateNewEncryptionKey bool

--- a/encode.go
+++ b/encode.go
@@ -162,6 +162,7 @@ var encode = &cli.Command{
 					}
 
 					stdout(nip19.EncodeNsec(sk))
+					zero(sk[:])
 				}
 
 				exitIfLineProcessingError(ctx)

--- a/encrypt_decrypt.go
+++ b/encrypt_decrypt.go
@@ -34,6 +34,7 @@ var encrypt = &cli.Command{
 			if err != nil {
 				return err
 			}
+			defer zero(sec[:])
 
 			if bunker != nil {
 				ciphertext, err := bunker.NIP04Encrypt(ctx, target, plaintext)
@@ -95,6 +96,7 @@ var decrypt = &cli.Command{
 			if err != nil {
 				return err
 			}
+			defer zero(sec[:])
 
 			if bunker != nil {
 				plaintext, err := bunker.NIP04Decrypt(ctx, source, ciphertext)

--- a/event.go
+++ b/event.go
@@ -191,6 +191,7 @@ example:
 		if err != nil {
 			return err
 		}
+		defer zero(sec[:])
 
 		jq, err := jqPrepare(c.String("jq"), c.Bool("jq-raw"))
 		if err != nil {

--- a/gift.go
+++ b/gift.go
@@ -65,6 +65,7 @@ a decoupled key (if it has been created or received with "nak dekey" previously)
 				if !c.Bool("use-our-identity-key") {
 					configPath := c.String("config-path")
 					eSec, has, err := getDecoupledEncryptionSecretKey(ctx, configPath, sender)
+					defer zero(eSec[:])
 					if has {
 						if err != nil {
 							return fmt.Errorf("our decoupled encryption key exists, but we failed to get it: %w; call `nak dekey` to attempt a fix or call this again with --encrypt-with-our-identity-key to bypass", err)
@@ -143,6 +144,7 @@ a decoupled key (if it has been created or received with "nak dekey" previously)
 						Tags:      nostr.Tags{{"p", recipient.Hex()}},
 					}
 					wrap.Sign(ephemeral)
+					zero(ephemeral[:])
 
 					// print the gift-wrap
 					wrapJSON, err := easyjson.Marshal(wrap)
@@ -176,6 +178,7 @@ a decoupled key (if it has been created or received with "nak dekey" previously)
 				// use decoupled key if it exists
 				configPath := c.String("config-path")
 				eSec, has, err := getDecoupledEncryptionSecretKey(ctx, configPath, receiver)
+				defer zero(eSec[:])
 				if has {
 					if err != nil {
 						return fmt.Errorf("receiver's decoupled encryption key exists, but we failed to get it: %w; call `nak dekey` to attempt a fix or call this again with --use-direct to bypass", err)
@@ -331,6 +334,7 @@ func getDecoupledEncryptionSecretKey(ctx context.Context, configPath string, pub
 			if err != nil {
 				return [32]byte{}, true, fmt.Errorf("invalid main key: %w", err)
 			}
+			defer zero(eSec[:])
 			if eSec.Public() != ePub {
 				return [32]byte{}, true, fmt.Errorf("stored decoupled encryption key at %s doesn't match the announced key %s", eKeyPath, ePub.Hex())
 			}

--- a/helpers.go
+++ b/helpers.go
@@ -501,13 +501,16 @@ func parsePubKey(value string) (nostr.PubKey, error) {
 
 func parseSecretKey(input string) (nostr.SecretKey, error) {
 	if prefix, ski, err := nip19.Decode(input); err == nil && prefix == "nsec" {
-		return ski.(nostr.SecretKey), nil
+		sk := ski.(nostr.SecretKey)
+		defer zero(sk[:])
+		return sk, nil
 	}
 
 	sk, err := nostr.SecretKeyFromHex(input)
 	if err != nil {
 		return nostr.SecretKey{}, fmt.Errorf("invalid secret key: %w", err)
 	}
+	defer zero(sk[:])
 
 	return sk, nil
 }

--- a/helpers_key.go
+++ b/helpers_key.go
@@ -39,6 +39,8 @@ func gatherKeyerFromArguments(ctx context.Context, c *cli.Command) (nostr.Keyer,
 		return nil, nostr.SecretKey{}, err
 	}
 
+	defer zero(key[:])
+
 	var kr nostr.Keyer
 	if bunker == nil {
 		kr = keyer.NewPlainKeySigner(key)
@@ -57,6 +59,7 @@ func gatherSecretKeyOrBunkerFromArguments(ctx context.Context, c *cli.Command) (
 		bunkerURL := sec
 
 		clientKey := getSecretKey(c, "connect-as")
+		defer zero(clientKey[:])
 		logverbose("[nip46]: connecting to %s with client key %s\n", bunkerURL, clientKey.Hex())
 
 		bunker, err := nip46.ConnectBunker(ctx, clientKey, bunkerURL, sys.Pool, func(s string) {
@@ -82,10 +85,12 @@ func gatherSecretKeyOrBunkerFromArguments(ctx context.Context, c *cli.Command) (
 		if err != nil {
 			return nostr.SecretKey{}, nil, fmt.Errorf("failed to decrypt: %w", err)
 		}
+		defer zero(sk[:])
 		return sk, nil, nil
 	}
 
 	sk, err := parseSecretKey(sec)
+	defer zero(sk[:])
 	return sk, nil, err
 }
 
@@ -132,6 +137,7 @@ func promptDecrypt(ncryptsec string) (nostr.SecretKey, error) {
 		if err != nil {
 			continue
 		}
+		defer zero(sec[:])
 		return sec, nil
 	}
 	return nostr.SecretKey{}, fmt.Errorf("couldn't decrypt private key")

--- a/key.go
+++ b/key.go
@@ -39,6 +39,7 @@ var generate = &cli.Command{
 	DisableSliceFlagSeparator: true,
 	Action: func(ctx context.Context, c *cli.Command) error {
 		sec := nostr.Generate()
+		defer zero(sec[:])
 		stdout(sec.Hex())
 		return nil
 	},
@@ -79,6 +80,8 @@ var public = &cli.Command{
 			} else {
 				stdout(hex.EncodeToString(pk.SerializeCompressed()[1:]))
 			}
+
+			zero(sk[:])
 		}
 		return nil
 	},
@@ -144,6 +147,7 @@ var encryptKey = &cli.Command{
 		}
 		for sec := range getSecretKeysFromStdinLinesOrSlice(ctx, c, keys) {
 			ncryptsec, err := nip49.Encrypt(sec, password, uint8(c.Int("logn")), 0x02)
+			zero(sec[:])
 			if err != nil {
 				ctx = lineProcessingError(ctx, "failed to encrypt: %s", err)
 				continue
@@ -174,6 +178,7 @@ var decryptKey = &cli.Command{
 			if err != nil {
 				return fmt.Errorf("failed to decrypt: %s", err)
 			}
+			defer zero(sk[:])
 			stdout(sk.Hex())
 			return nil
 		case 1:
@@ -182,6 +187,7 @@ var decryptKey = &cli.Command{
 				if sk, err := promptDecrypt(ncryptsec); err != nil {
 					return err
 				} else {
+					defer zero(sk[:])
 					stdout(sk.Hex())
 					return nil
 				}
@@ -195,6 +201,7 @@ var decryptKey = &cli.Command{
 						continue
 					}
 					stdout(sk.Hex())
+					zero(sk[:])
 				}
 				exitIfLineProcessingError(ctx)
 				return nil
@@ -412,6 +419,9 @@ func getSecretKeysFromStdinLinesOrSlice(ctx context.Context, _ *cli.Command, key
 			}
 
 			ch <- sk
+			// the receiver got its own copy above (channel sends copy by
+			// value), so it's safe to wipe ours now
+			zero(sk[:])
 		}
 		close(ch)
 	}()

--- a/musig2.go
+++ b/musig2.go
@@ -49,6 +49,8 @@ func performMusig(
 	secNonce string,
 	partialSigs []string,
 ) (signed bool, err error) {
+	defer zero(sec[:])
+
 	// preprocess data received
 	seck, pubk := btcec.PrivKeyFromBytes(sec[:])
 

--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,26 @@
+package main
+
+// zero overwrites b with zero bytes. It is used to wipe sensitive data (raw
+// private key bytes, decrypted secret keys) from memory as soon as we are
+// done using it, so it doesn't linger around for longer than necessary.
+//
+// Callers should invoke this via `defer zero(sk[:])` right after obtaining a
+// nostr.SecretKey they own (as a local variable, parameter, or a value about
+// to be returned -- deferred calls run after the return value has already
+// been copied out, so this never changes what gets returned) or, inside a
+// loop, with a direct call as soon as that iteration's copy is no longer
+// needed.
+//
+// This is a best-effort hygiene measure, not a hard security guarantee: Go
+// copies values freely (by assignment, by being boxed into an interface, by
+// being handed to other libraries that keep their own copy) and this
+// function can only reach the specific copy it's given. See the "known
+// limitations" note in the PR/commit that introduced this file for a
+// rundown of the copies that are out of nak's reach.
+//
+//go:noinline
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"fiatjaf.com/nostr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZero(t *testing.T) {
+	b := []byte{1, 2, 3, 4, 5, 255, 128, 9}
+	zero(b)
+	for i, v := range b {
+		require.Equalf(t, byte(0), v, "byte %d was not zeroed", i)
+	}
+}
+
+func TestZeroEmptyAndNil(t *testing.T) {
+	// must not panic on the degenerate cases
+	zero(nil)
+	zero([]byte{})
+}
+
+// TestParseSecretKeyDoesNotLeaveDecodedBytesReadable is a best-effort check
+// that the defer-based zeroing added around key parsing actually happens:
+// it exercises parseSecretKey (which internally defers zero() on its local
+// copy of the decoded key before returning) and confirms the function still
+// returns the correct, untouched key to its caller -- proving the deferred
+// zero of the *local* copy does not corrupt the *returned* copy, which is
+// the core safety property the whole approach relies on.
+func TestParseSecretKeyReturnsUnmodifiedValueDespiteInternalZeroing(t *testing.T) {
+	want := nostr.Generate()
+
+	got, err := parseSecretKey(want.Hex())
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.NotEqual(t, nostr.SecretKey{}, got, "sanity: returned key should not be the zero key")
+}


### PR DESCRIPTION
Closes #146.

## What this does

`nostr.SecretKey` (`[32]byte`) is defined upstream in `fiatjaf.com/nostr`
(the module the issue calls `nostrlib` — it's since been renamed/moved to
`fiatjaf.com/nostr`, confirmed by checking `keys.go` there directly; it
provides no `Zero`/`Clear` method, and I found no zeroing helper already
vendored anywhere in nak's dependency tree that could be reused instead).

This PR adds a small helper:

```go
//go:noinline
func zero(b []byte) {
	for i := range b {
		b[i] = 0
	}
}
```

(`//go:noinline` so the compiler can't reason across the call boundary and
decide the loop is dead — this is the standard, low-risk technique for this
in Go; slices/arrays like this aren't subject to the kind of dead-store
elimination C compilers do with `memset` before a buffer is freed, but the
noinline pragma removes any doubt.)

...and wires it in via `defer zero(sk[:])` immediately after every local
`nostr.SecretKey` variable/parameter that nak's own code owns, across every
command and helper that touches one: `key generate/public/encrypt/decrypt`,
`decode`, `encode`, `dekey`, `gift wrap/unwrap`, `encrypt`/`decrypt` (nip04),
the shared `gatherKeyerFromArguments` / `gatherSecretKeyOrBunkerFromArguments`
/ `parseSecretKey` / `promptDecrypt` helpers (used by nearly every other
command that needs a key — `admin`, `blossom`, `curl`, `event`, `fs`, `mcp`,
`nsite`, `publish`, `req`, `spell`, `wallet`, `git`, `group`, etc. all funnel
through these), `bunker` (the long-lived signing key, zeroed once the
command actually returns/shuts down), and musig2 signing.

Why this is safe and doesn't change behavior: `defer`'s arguments are
evaluated at the `defer` statement (capturing the variable's address, not a
snapshot of its value), and Go copies a function's return value(s) out
*before* running its deferred calls. So `defer zero(sk[:])` placed right
after a key is obtained — even in a function that returns that very key —
never changes what gets returned; it only wipes the local copy afterwards,
once it's genuinely no longer needed. Inside loops (e.g. reading many keys
from stdin) I used a direct `zero(sk[:])` call instead of `defer`, right
after each key's last use, so we don't pile up deferred calls for large
batch inputs.

## What this deliberately does NOT cover, and why

Being upfront about the gaps rather than overstating coverage:

- **`ncryptsec1` passwords** (the other thing #146 asks about) stay as Go
  `string`s the whole way through: prompted via `readline`/`go-tty` (both
  return `string`), then passed to `nip49.Decrypt`/`nip49.Encrypt`, which
  take `password string` upstream in `fiatjaf.com/nostr/nip49`. Go strings
  are immutable — safely zeroing one requires `unsafe` pointer tricks (not
  guaranteed-safe across Go versions/runtimes, and risky to rely on) or
  changing `nip49`'s API to accept `[]byte`. That's an upstream
  `fiatjaf.com/nostr` change, not something fixable from nak alone, so I
  left it out rather than reach for `unsafe`.
- **Copies made by `nip19.Decode`**: it returns `(prefix string, value any,
  err error)`, boxing the decoded `nostr.SecretKey` into an `interface{}`.
  That boxing allocates its own copy on the heap that nak's code has no
  handle to and can't zero. Only reachable by changing `nip19`'s decode API
  upstream.
- **Copies intentionally kept alive** for as long as they're needed: the
  key stored inside a `keyer.PlainKeySigner` (`fiatjaf.com/nostr/keyer`
  keeps its own internal copy for the signer's lifetime — needed for every
  subsequent sign/encrypt call) and the `*nostr.SecretKey` persisted inside
  `bunker.go`'s `plainOrEncryptedKey` (needed for the bunker config's JSON
  persistence and equality checks across the whole `nak bunker` session).
  Zeroing these early would either require upstream changes or would break
  the command's actual behavior, so I left them alone — the `bunker`
  command's own top-level `sec` (the copy actually used for signing) is
  what gets zeroed once the command returns.
- The `--sec`/`--connect-as` flag value cached inside `flags.go`'s
  `secretkeyValue` (backing `urfave/cli`'s flag storage) for the whole
  command's argument-parsing lifetime, since it may legitimately be read
  more than once during a single command run.

So: this is a real, meaningful reduction in how long decoded key bytes sit
around in nak's own memory, but not a complete "nothing ever lingers"
guarantee — full coverage of the password and interface-boxing cases would
need changes in `fiatjaf.com/nostr` itself.

## QA / verification

- `go build .` and `go vet .` — clean.
- Full existing test suite (`go test .`) — all passing except one
  pre-existing, unrelated failure in `TestEventBasic` that I confirmed
  reproduces identically on a clean checkout of `master` with none of my
  changes applied (it asserts a hardcoded pubkey/sig derived from
  `defaultKey()`, which is seeded from this machine's `machineid` — so it's
  expected to fail on any machine other than the original author's, not
  something this PR touches).
- Added `secrets_test.go`: a direct test that `zero()` actually clears a
  slice, and a test confirming `parseSecretKey` still returns the correct,
  unmodified key to its caller despite deferring a zero of its own internal
  copy — verifying the core safety property (deferred zero of a local
  never corrupts an already-copied-out return value) actually holds.
- Manually exercised `nak key generate`, `nak key public`, `nak key
  encrypt`/`decrypt`, `nak encode nsec`, `nak decode <nsec>` to confirm
  output is byte-for-byte identical to before this change.

## Disclosure

Investigated, written, and tested with AI assistance (Claude), same as
#186. I reviewed the diff and the reasoning above myself before opening
this.