### PR TITLE
nostrfs: reuse pooled relay connections when publishing notes

### DIFF
--- a/nostrfs_cgo/root.go
+++ b/nostrfs_cgo/root.go
@@ -996,13 +996,18 @@ func (r *NostrRoot) publishNote(path string) {
 	}
 
 	for _, url := range relays {
-		connectCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		relay, err := nostr.RelayConnect(connectCtx, url, r.sys.Pool.RelayOptions)
-		cancel()
-		if err != nil {
-			continue
+		nm := nostr.NormalizeURL(url)
+		relay, ok := r.sys.Pool.Relays.Load(nm)
+		if !ok || relay == nil || !relay.IsConnected() {
+			connectCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			var err error
+			relay, err = nostr.RelayConnect(connectCtx, url, r.sys.Pool.RelayOptions)
+			cancel()
+			if err != nil {
+				continue
+			}
+			r.sys.Pool.Relays.Store(nm, relay)
 		}
-		r.sys.Pool.Relays.Store(nostr.NormalizeURL(url), relay)
 		relay.Publish(ctx, *evt)
 	}
 


### PR DESCRIPTION
publishNote dialed a fresh websocket on every publish and overwrote the pooled relay without closing the old one, so the long-running FUSE process leaked one connection per outbox relay per note. Use the same load-or-connect pattern as the other call sites.