### PR TITLE
bunker: re-render the qr code when the secret rotates

### DIFF
--- a/bunker.go
+++ b/bunker.go
@@ -429,7 +429,14 @@ var bunker = &cli.Command{
 		}
 
 		setBunkerInfo := func() {
-			info, _ := bunkerInfo()
+			info, bunkerURI := bunkerInfo()
+			if c.Bool("qrcode") {
+				// the secret embedded in the bunker uri may have rotated,
+				// so the qr code on screen has to be rendered again
+				qr := strings.Builder{}
+				qrterminal.Generate(bunkerURI, qrterminal.L, &qr)
+				terminal.Log("QR Code for bunker URI:\n%s\n", qr.String())
+			}
 			terminal.SetFooter(info)
 		}
 


### PR DESCRIPTION
After the first client connects the secret rotates, but the QR code on screen still encodes the burnt secret, so a second scan is silently denied. Before the footer refactor the QR was re-rendered along with the info; restore that.