### PR TITLE
fetch, group: fix web address scheme guessing

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -176,7 +176,16 @@ func isWebAddress(code string) bool {
 
 func guessWebScheme(code string) string {
 	host, _, _ := strings.Cut(code, "/")
-	if strings.HasPrefix(host, "localhost") || strings.HasPrefix(host, "127.0.0.1") {
+	if strings.HasPrefix(host, "[") {
+		// ipv6 literal, keep only the bracketed part
+		if i := strings.Index(host, "]"); i != -1 {
+			host = host[:i+1]
+		}
+	} else if h, _, ok := strings.Cut(host, ":"); ok {
+		// strip port
+		host = h
+	}
+	if host == "localhost" || host == "127.0.0.1" || host == "[::1]" {
 		return "http://"
 	}
 	return "https://"

--- a/group.go
+++ b/group.go
@@ -995,7 +995,12 @@ func parseGroupIdentifier(ctx context.Context, c *cli.Command) (relay string, id
 		identifier = ptr.Identifier
 		author = ptr.PublicKey
 	} else if isWebAddress(groupArg) {
-		webPath, err := nipad.Resolve(ctx, groupArg)
+		addr := groupArg
+		if !strings.HasPrefix(addr, "http://") && !strings.HasPrefix(addr, "https://") {
+			addr = guessWebScheme(addr) + addr
+		}
+
+		webPath, err := nipad.Resolve(ctx, addr)
 		if err != nil {
 			return "", "", nostr.ZeroPK, fmt.Errorf("failed to resolve group address '%s': %w", groupArg, err)
 		}


### PR DESCRIPTION
`guessWebScheme` matched hosts by prefix, so `localhost.evil.com` was resolved over plaintext http. Compare the host exactly instead. Also apply the same scheme guessing to `nak group` web addresses, which always went to https and so never worked against local plain-http relays.