### PR TITLE
git: sort 'history' in reverse chronological order

### DIFF
--- a/git.go
+++ b/git.go
@@ -800,6 +800,20 @@ aside from those, there is also:
 						continue
 					}
 
+					// they come back in a depth-first order that walks the first parent
+					// all the way down to the root before visiting merged branches, so
+					// put them in reverse chronological order like 'git log' does
+					slices.SortStableFunc(commits, func(a, b *gitnaturalapi.Commit) int {
+						switch {
+						case a.Committer.Timestamp > b.Committer.Timestamp:
+							return -1
+						case a.Committer.Timestamp < b.Committer.Timestamp:
+							return 1
+						default:
+							return 0
+						}
+					})
+
 					for _, c := range commits {
 						date := time.Unix(c.Author.Timestamp, 0).Format(time.DateOnly)
 						stdout(


### PR DESCRIPTION
The api returns commits in a depth-first order that walks the first parent down to the root before visiting merged branches, so on urfave/cli the 2013 root commit was printed at line 968 of 3890 and the remaining 2922 commits climbed back up in ascending order. Sorting by commit date makes the output match `git log --date-order`.