### PR TITLE
git: don't trim whitespace off paths in 'ls' and 'cat'

### DIFF
--- a/git.go
+++ b/git.go
@@ -631,7 +631,7 @@ aside from those, there is also:
 					return fmt.Errorf("no HTTP git URLs found for repository")
 				}
 
-				path := strings.TrimSpace(args.Get(1))
+				path := args.Get(1)
 				ref := strings.TrimSpace(c.String("ref"))
 
 				var lastErr error
@@ -701,7 +701,7 @@ aside from those, there is also:
 					return fmt.Errorf("no HTTP git URLs found for repository")
 				}
 
-				path := strings.TrimSpace(args.Get(1))
+				path := args.Get(1)
 				ref := strings.TrimSpace(c.String("ref"))
 
 				var lastErr error


### PR DESCRIPTION
Git path names may legitimately begin or end with a space, and `download` already passes the path through untouched. `ls` listed such entries while neither `ls` nor `cat` could then descend into or read them.