### PR TITLE
git: fix 'cat' returning the wrong file for paths with a backslash

### DIFF
--- a/git.go
+++ b/git.go
@@ -717,19 +717,43 @@ aside from those, there is also:
 						continue
 					}
 
-					entry, err := gitnaturalapi.GetObjectByPath(url, commit, path)
+					// the path is walked here instead of with GetObjectByPath()
+					// because that also treats '\' as a separator, while in git
+					// path names a backslash is just a regular character
+					segments := strings.Split(strings.Trim(path, "/"), "/")
+					name := segments[len(segments)-1]
+
+					depth := len(segments)
+					tree, err := gitnaturalapi.GetDirectoryTreeAt(url, commit, &depth)
 					if err != nil {
 						lastErr = err
 						continue
 					}
-					if entry == nil {
-						return fmt.Errorf("path '%s' not found", path)
-					}
-					if entry.IsDir {
-						return fmt.Errorf("path '%s' is a directory", path)
+
+					if len(segments) > 1 {
+						tree, err = gitTreeAtPath(tree, strings.Join(segments[:len(segments)-1], "/"))
+						if err != nil {
+							return err
+						}
 					}
 
-					obj, err := gitnaturalapi.GetObject(url, entry.Hash)
+					hash := ""
+					for _, file := range tree.Files {
+						if file.Name == name {
+							hash = file.Hash
+							break
+						}
+					}
+					if hash == "" {
+						for _, dir := range tree.Directories {
+							if dir.Name == name {
+								return fmt.Errorf("path '%s' is a directory", path)
+							}
+						}
+						return fmt.Errorf("path '%s' not found", path)
+					}
+
+					obj, err := gitnaturalapi.GetObject(url, hash)
 					if err != nil {
 						lastErr = fmt.Errorf("download error: %s", err)
 						continue


### PR DESCRIPTION
`GetObjectByPath` rewrites `\` to `/` before resolving, but on git a backslash is an ordinary character in a path name. In a repository holding both `dir/f.txt` and `dir\f.txt`, `cat dir\f.txt` printed the contents of `dir/f.txt` and exited 0; where no such directory exists the file was simply unreachable although `ls` listed it. The path is now walked splitting only on `/`, keeping the same depth-limited fetch.