### PR TITLE
truncate text by runes instead of bytes

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"fiatjaf.com/nostr"
 	"fiatjaf.com/nostr/nip05"
@@ -621,11 +622,14 @@ func editWithDefaultEditor(filename string, initialContent string, wipe bool) (s
 	return string(data), nil
 }
 
+// clampWithEllipsis shortens s to at most size characters. it counts runes and
+// not bytes, otherwise it would cut multibyte characters in half.
 func clampWithEllipsis(s string, size int) string {
-	if len(s) <= size {
+	if utf8.RuneCountInString(s) <= size {
 		return s
 	}
-	return s[0:size-1] + "…"
+	runes := []rune(s)
+	return string(runes[0:size-1]) + "…"
 }
 
 var (

--- a/podcast.go
+++ b/podcast.go
@@ -593,10 +593,7 @@ func printPodcastEpisodeList(ctx context.Context, p podcastInfo, limit int) erro
 			title = ep.ID.Hex()[:16]
 		}
 		date := ep.CreatedAt.Time().Format("2006-01-02")
-		desc := ep.Content
-		if len(desc) > 100 {
-			desc = desc[:100] + "..."
-		}
+		desc := clampWithEllipsis(ep.Content, 100)
 		stdout(fmt.Sprintf("%s  %s  %s", date, title, desc))
 	}
 


### PR DESCRIPTION
`clampWithEllipsis` sliced the string by bytes, so any text with multibyte characters could be cut in the middle of one and printed as invalid UTF-8. With a Japanese podcast description, 64 of the 101 clamp sizes between 20 and 120 produced a broken string, and the whole `nak podcast list` output failed to decode. It affects the patch and pull request subject previews in `git`, the forum subject previews in `group`, and the name and description previews in `spell`. `podcast list` had its own copy of the same byte slicing and now uses the shared helper.